### PR TITLE
Add GC-Prevue

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ This list is for websites, services, software, tools and more: everything that y
 
 ### Installable
 - [Gerbv](http://gerbv.geda-project.org/) - Excellent Gerber viewer for Linux and BSD.
-- [KiCAD Gerbview](http://kicad.org/) - The KiCAD gerber viewer.
+- [KiCAD Gerbview](https://kicad.org/) - The KiCAD gerber viewer.
 - [GC-Prevue](http://www.graphicode.com/GC-Prevue_Gerber_Viewer) - Commercial with free version. Can handle some gerbers better than Gerbv and KiCAD.
 
 ## Free EDA Packages

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This list is for websites, services, software, tools and more: everything that y
 ### Installable
 - [Gerbv](http://gerbv.geda-project.org/) - Excellent Gerber viewer for Linux and BSD.
 - [KiCAD Gerbview](http://kicad-pcb.org/) - The KiCAD gerber viewer.
+- [GC-Prevue](http://www.graphicode.com/GC-Prevue_Gerber_Viewer) - Commercial with free version. Can handle some gerbers better than Gerbv and KiCAD.
 
 
 ## Miscellaneous Web Services

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ This list is for websites, services, software, tools and more: everything that y
 
 ### Installable
 - [Gerbv](http://gerbv.geda-project.org/) - Excellent Gerber viewer for Linux and BSD.
-- [KiCAD Gerbview](http://kicad-pcb.org/) - The KiCAD gerber viewer.
+- [KiCAD Gerbview](http://kicad.org/) - The KiCAD gerber viewer.
 - [GC-Prevue](http://www.graphicode.com/GC-Prevue_Gerber_Viewer) - Commercial with free version. Can handle some gerbers better than Gerbv and KiCAD.
 
 ## Free EDA Packages


### PR DESCRIPTION
Normally I would prefer using open source programs, but GC-Prevue is a) actually very good, and b) renders some gerbers more correctly than gerbv, e.g. those produced by DesignSpark PCB.