### PR TITLE
Add Micro-Cap to simulator list

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This list is for websites, services, software, tools and more: everything that y
 - [Every Circuit](http://everycircuit.com) - Free to try online, visual, interactive circuit simulator for simpler circuits.
 - [Qucs](http://qucs.sourceforge.net/) - Open source integrated circuit simulator for DC, AC, S-parameter, noise analysis, etc.
 - [iCircuit](http://icircuitapp.com/) - Easy to use electronic circuit simulator, its advanced simulation engine can handle both analog and digital circuits and features realtime always-on analysis.
+- [Micro-Cap](http://www.spectrum-soft.com/download/download.shtm) - Professional-grade mixed signal simulator with wide variety of interactive simulation types. 
   
 ## Gerber Viewers
 


### PR DESCRIPTION
Spectrumsoft recently shut its business and made their simulator free to download. Adding to the list on account of being much more accessible.