### PR TITLE
Add JLCSearch - Find most popular/in-stock jlcpcb parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ This list is for websites, services, software, tools and more: everything that y
 - [Findchips](https://www.findchips.com/) - Part search from Supply Frame.
 - [Parts.io](https://parts.io/) - Another search engine from Supply Frame geared towards discovering new parts.
 - [Electronic Component Search Engine](https://componentsearchengine.com/) - Free access to schematic symbols, PCB footprints and 3D models.
-- [Yoo Need One - SMD Marking Database](https://smd.yooneed.one/) - Surface Mount Device (SMD) component marking database. 
+- [Yoo Need One - SMD Marking Database](https://smd.yooneed.one/) - Surface Mount Device (SMD) component marking database.
+- [JLCSearch](https://jlcsearch.tscircuit.com) - Find the most popular in-stock JLC components for different categories
 
 
 ## Project Sharing Platforms


### PR DESCRIPTION
This is an [open-source project](https://github.com/tscircuit/jlcsearch) we built to make it easy to find the most popular, in-stock parts on jlcpcb.

It's perfect for people who want to make sure the parts they're selecting are popular, or for selecting new modules.

We use it almost every day and it's changed my mind on e.g. [selecting a wifi module](https://jlcsearch.tscircuit.com/wifi_modules/list) because I saw there were more popular and "likely to be in-stock indefinitely" parts available

![image](https://github.com/user-attachments/assets/43d3dc90-1d12-455a-8660-a3d85b7de331)
