### PR TITLE
Remove "1-click BOM" from "Inventory Management and Purchasing" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,6 @@ This list is for websites, services, software, tools and more: everything that y
 
 
 ## Inventory Management and Purchasing
-- [1-click BOM](https://kitspace.org/1-click-bom/) - Browser extensions that automates purchasing and part searching.
 - [PartsBox](https://partsbox.io) - Web service to manage your part inventory with a nice user interface and Octopart integration.
 - [PartKeepr](https://partkeepr.org) - Open source web service for managing your part inventory with parametric search and automatic datasheet import.
 - [Part-DB](https://github.com/Part-DB/Part-DB) - Another open source web service for managing part inventory with a permission system and a good barcode generator.


### PR DESCRIPTION
The url [https://kitspace.org/1-click-bom/](https://kitspace.org/1-click-bom/) redirects to Github page which is not available anymore.

<img width="1440" alt="SCR-20250130-kleg" src="https://github.com/user-attachments/assets/2841e13b-037f-4335-ad89-b45264b4936a" />
