### PR TITLE
Add Link Budget Calculator to Miscellaneous Software Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ This list is for websites, services, software, tools and more: everything that y
 ## Miscellaneous Software Projects
 - [SnapEDA](https://www.snapeda.com) - Parts library with free symbols & footprints. (Compatible with Eagle, KiCad, Altium, OrCad, Allegro, etc.)
 - [Language PCB](https://github.com/Alhadis/language-pcb) - Syntax highlighting for various PCB formats.
+- [Link Budget Calculator](https://github.com/galenthas/link-budget-calculator) - Free, open-source RF/satellite link budget calculator for Windows with ITU-R atmospheric models, sweep plots, and PDF reports.
 - [NinjaCalc](https://gbmhunter.github.io/NinjaCalc/) - An embedded engineering calculator toolbox for doing calculations in a breeze.
 - [Saturn PCB Design Toolkit](https://saturnpcb.com/saturn-pcb-toolkit/) - The Saturn PCB Toolkit is the best freeware resource for PCB related calculations you can find.
 - [KiCanvas](https://kicanvas.org/) - An open source online viewer of KiCad schematics and boards.


### PR DESCRIPTION
Adds [Link Budget Calculator](https://github.com/galenthas/link-budget-calculator) — a free, open-source native Windows GUI for RF and satellite link budget analysis.

It fits the **Miscellaneous Software Projects** section alongside NinjaCalc and Saturn PCB Toolkit as an engineering calculator tool.

**What it does:**
- Computes EIRP, free-space path loss, C/N0, Eb/N0, and link margin
- ITU-R P.676-12 gaseous attenuation and P.838-3 rain attenuation models
- Parameter sweep plots with zero-crossing detection
- PDF report and CSV export
- MIT licensed, written in C11, 141 unit tests